### PR TITLE
Feat pecas endpoint

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,14 +6,21 @@ phases:
       nodejs: 23
     commands:
       - aws codeartifact login --tool npm --repository autoservice-dependencies --domain autoservice --domain-owner 055542020254 --region us-east-1
-    # - npm install -g pnpm
+      - npm install -g pnpm
+      - pnpm install
+      - git diff --quiet HEAD^ HEAD -- package.json || export PACKAGE_JSON_CHANGED=true
   build:
     commands:
-      - npm install
-      - npm run build
+      - if [ "$PACKAGE_JSON_CHANGED" = "true" ]; then pnpm install; fi
+      - pnpm run build
+
   post_build:
     commands:
       - echo "Build completed successfully"
+
+cache:
+  paths:
+    - "node_modules/**/*"
 artifacts:
   files:
     - "**/*"
@@ -25,3 +32,17 @@ artifacts:
     - "Docker*"
     - "laravel/**/*"
     - "app/**/*"
+    - "test/**/*"
+    - "docs/**/*"
+  discard-paths: no
+  base-directory: .
+  name: artifact-$(date +%Y-%m-%d)
+  secondary-artifacts:
+    node_modules_artifact:
+      files:
+        - "node_modules/**/*"
+      discard-paths: no
+      base-directory: .
+      name: node_modules-$(date +%Y-%m-%d)
+      when:
+        - $PACKAGE_JSON_CHANGED = "true"

--- a/prisma/schema/views.prisma
+++ b/prisma/schema/views.prisma
@@ -75,3 +75,19 @@ view fontes_pagadoras_view {
 
     @@unique(name: "fp_view", [parent, parent_id, numero_do_dn])
 }
+
+view pecas_balcao_view {
+    numero_do_dn       String  @unique
+    mes_ano            String
+    qtd_pecas_balcao   BigInt
+    vl_liq_peca_balcao Decimal @db.Decimal(10, 2)
+}
+
+view pecas_oficina_view {
+    numero_do_dn        String  @unique
+    mes_ano             String
+    qtd_pecas_oficina   BigInt
+    vl_liq_peca_oficina Decimal @db.Decimal(10, 2)
+    qtd_hora_vendida    Float
+    vl_liq_mao_obra     Decimal @db.Decimal(10, 2)
+}

--- a/src/autoservice/autoservice.controller.ts
+++ b/src/autoservice/autoservice.controller.ts
@@ -79,4 +79,20 @@ export class AutoserviceController {
   async servicesStateYear(@Query('year') year?: number) {
     return this.autoserviceService.getServicesStateYear(year);
   }
+
+  @Get('pecas_balcao')
+  @ApiQuery({ name: 'year', required: true, type: Number })
+  @ApiQuery({ name: 'month', required: false, type: Number })
+  @ApiQuery({ name: 'dn', required: false, type: String })
+  async pecasBalcao(@Query('year') year: number, @Query('month') month?: number, @Query('dn') dn?: string) {
+    return this.autoserviceService.getPecasBalcao(year, month, dn);
+  }
+
+  @Get('pecas_oficina')
+  @ApiQuery({ name: 'year', required: true, type: Number })
+  @ApiQuery({ name: 'month', required: false, type: Number })
+  @ApiQuery({ name: 'dn', required: false, type: String })
+  async pecasOficina(@Query('year') year: number, @Query('month') month?: number, @Query('dn') dn?: string) {
+    return this.autoserviceService.getPecasOficina(year, month, dn);
+  }
 }

--- a/src/autoservice/autoservice.service.ts
+++ b/src/autoservice/autoservice.service.ts
@@ -47,20 +47,11 @@ export class AutoserviceService implements OnModuleInit {
     this.attempts = 0;
     this.autoserviceQueue.drain();
     await Promise.all([
-      this.startProcess(2024, 2),
-      this.startProcess(2025, 2),
+      this.startProcess(2024, 5),
+      this.startProcess(2025, 5),
     ]);
   }
 
-
-  // @Interval(2000)
-  // async testSqs() {
-  // console.log('teste bull', await this.getBullMqStatus());
-  //   console.log('vazio?', this.sqsEmpty);
-  //   console.log('status', await this.getSqsStatus());
-
-  // console.log((await this.autoserviceQueue.client).status)
-  // }
 
   @Interval(10000)
   async retryFailedJobs() {
@@ -181,7 +172,6 @@ export class AutoserviceService implements OnModuleInit {
       console.log(error);
     }
   }
-
 
   async fetch(url, params, method, endpoint = null, category = null, token = null) {
     const path = endpoint ? new URL(endpoint, url) : new URL(url);
@@ -750,5 +740,41 @@ export class AutoserviceService implements OnModuleInit {
       page: skip,
       data
     };
+  }
+
+  async getPecasBalcao(year: number, month?: number, dn?: string) {
+    const where: any = {
+      mes_ano: {
+        startsWith: year.toString()
+      }
+    };
+
+    if (month !== undefined) {
+      where.mes_ano.endsWith = month.toString();
+    }
+
+    if (dn !== undefined) {
+      where.numero_do_dn = dn;
+    }
+
+    return this.prisma.pecas_balcao_view.findMany({ where });
+  }
+
+  async getPecasOficina(year: number, month?: number, dn?: string) {
+    const where: any = {
+      mes_ano: {
+        startsWith: year.toString()
+      }
+    };
+
+    if (month !== undefined) {
+      where.mes_ano.endsWith = month.toString();
+    }
+
+    if (dn !== undefined) {
+      where.numero_do_dn = dn;
+    }
+
+    return this.prisma.pecas_oficina_view.findMany({ where });
   }
 }


### PR DESCRIPTION
criados dois endpoints novos para retornar peças de balcão e oficina baseados nos dados das respectivas views
alterado script buildspec para usar pnpm e codeartifcat, além de usar cache para quando as dependencias não são alteradas