### PR TITLE
Alterado mês de 2025 para março

### DIFF
--- a/src/autoservice/autoservice.service.ts
+++ b/src/autoservice/autoservice.service.ts
@@ -48,7 +48,7 @@ export class AutoserviceService implements OnModuleInit {
     this.autoserviceQueue.drain();
     await Promise.all([
       this.startProcess(2024, 5),
-      this.startProcess(2025, 5),
+      this.startProcess(2025, 2),
     ]);
   }
 


### PR DESCRIPTION
a rotina de coleta de dados retroativa estáva com o mês errado para 2025, corrigido para iniciar a partir de março