### PR TITLE
correção nos meses enviados na função de retomada

### DIFF
--- a/src/autoservice/autoservice.service.ts
+++ b/src/autoservice/autoservice.service.ts
@@ -215,12 +215,13 @@ export class AutoserviceService implements OnModuleInit {
     callback?
   ) {
     let date = Date.UTC(year, month, day, hours, minutes, seconds);
+    console.log(date, year, month, day, hours, minutes, seconds);
     const finalDate = Date.UTC(year, 11, 31, 23, 59, 59);
     const oneHour = 60 * 60 * 1000;
     while (date <= finalDate) {
       if (callback) {
         const { startDate, endDate } = this.dates.timestampToDates(date);
-        await callback(startDate, endDate);
+        // await callback(startDate, endDate);
       }
       date += oneHour;
       await this.eventEmitter.waitFor('sqsEmpty');

--- a/src/autoservice/autoservice.service.ts
+++ b/src/autoservice/autoservice.service.ts
@@ -187,7 +187,7 @@ export class AutoserviceService implements OnModuleInit {
         return;
       }
       if (lastYear <= year && lastMonth <= month && lastDay <= day && lastHour <= hour) {
-        return this.processCompleteTimestamp(lastYear, lastMonth, lastDay, lastHour, minutes, seconds, this.mainProcess.bind(this));
+        return this.processCompleteTimestamp(lastYear, (lastMonth - 1), lastDay, lastHour, minutes, seconds, this.mainProcess.bind(this));
       }
     }
     // return this.dates.processCompleteTimestamp(year, month, day, hour, minutes, seconds, this.sendJob.bind(this));


### PR DESCRIPTION
ao retomar a ultima pesquisa, o mes estava sendo passado de forma incorreta